### PR TITLE
TypeError->DataError

### DIFF
--- a/test/objectstore.delete.js
+++ b/test/objectstore.delete.js
@@ -556,7 +556,7 @@ QUnit.test("Deleting data - no key", function (assert) {
                     };
                 }
                 catch (ex){
-                    assert.equal(ex.name, "TypeError", ex.name);
+                    assert.equal(ex.name, "DataError", ex.name);
                 }
 
                 transaction.oncomplete = function (e){


### PR DESCRIPTION
As per http://w3c.github.io/IndexedDB/#dom-idbobjectstore-delete , for `IDBObjectStore.delete`, the one mention of processing the query argument is: "Let range be the result of running the steps to convert a value to a key range with query and null disallowed flag set. Rethrow any exceptions."

Since the steps to convert a value to a key range at http://w3c.github.io/IndexedDB/#convert-a-value-to-a-key-range , mention that a `DataError` should be thrown with the "null disallowed flag" and the value being `undefined` or `null`, I'd think that a missing argument (which is equivalent to `undefined` should do the same. The use of `TypeError` is not mentioned in these steps.
